### PR TITLE
feat: support `VoidComponent` type annotation

### DIFF
--- a/src/check-func/check-func-annotation.cjs
+++ b/src/check-func/check-func-annotation.cjs
@@ -6,7 +6,8 @@ const possibleAnnotationKinds = ['type', 'ctf', 'pragma']
 
 
 /**
- * Checks if the function is annotated with the `Component` or `ParentComponent` types or the `component` CTF.
+ * Checks if the function is annotated with the `Component`, `ParentComponent`,
+ * or `VoidComponent` types or the `component` CTF.
  * @todo Add support for pragma annotations.
  */
 function checkFuncAnnotation(opts, path, state) {

--- a/src/check-func/check-type-annotation.cjs
+++ b/src/check-func/check-type-annotation.cjs
@@ -21,14 +21,16 @@ function checkTypeAnnotation(path) {
 		if (importSpecifier.type !== "ImportSpecifier") return false
 		if (
 			importSpecifier.imported.name !== "Component"
-			&& importSpecifier.imported.name !== "ParentComponent"
+      && importSpecifier.imported.name !== "ParentComponent"
+      && importSpecifier.imported.name !== "VoidComponent"
 		) return false
 		if (typeBinding.path.parent.source.value !== "solid-js") return false
 	}
 	else if (typeAnnotation.typeName.type === "TSQualifiedName") {
 		if (
 			typeAnnotation.typeName.right.name !== "Component"
-			&& typeAnnotation.typeName.right.name !== "ParentComponent"
+      && typeAnnotation.typeName.right.name !== "ParentComponent"
+      && typeAnnotation.typeName.right.name !== "VoidComponent"
 		) return false
 		const typeQualification = typeAnnotation.typeName.left
 		if (typeQualification.type !== "Identifier") return false

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -7,6 +7,8 @@ test('index', async () => {
    await testBasicCase()
 	await testAliasedCtf()
 	await testComponentTypeAnnotation()
+	await testParentComponentTypeAnnotation()
+	await testVoidComponentTypeAnnotation()
 	await testAliasedTypeAnnotation()
 	await testDefaultProps()
    await testFallbackProps()
@@ -117,6 +119,32 @@ const comp: ParentComponent = _props => {
   _props.b;
 };
 const comp2: ParentComponent<T> = _props2 => {
+  _props2.a;
+  _props2.b;
+};`
+
+	const res = await transformAsync(
+		src,
+		{ plugins: ["@babel/plugin-syntax-typescript", "./src/index.cjs"] }
+	)
+
+	assert.snapshot(res.code, expectedOutput, 'TS annotation.')
+}
+
+
+async function testVoidComponentTypeAnnotation() {
+	const src =
+/*javascript*/`import type { VoidComponent } from 'solid-js';
+const comp: VoidComponent = ({ a, b }) => {a; b;};
+const comp2: VoidComponent<T> = ({ a, b }) => {a; b;};`
+
+	const expectedOutput =
+/*javascript*/`import type { VoidComponent } from 'solid-js';
+const comp: VoidComponent = _props => {
+  _props.a;
+  _props.b;
+};
+const comp2: VoidComponent<T> = _props2 => {
   _props2.a;
   _props2.b;
 };`


### PR DESCRIPTION
## Description

`VoidComponent` is another SolidJS type alias mentioned on https://www.solidjs.com/guides/typescript#component-types. It's a shorthand for a component that has no `children` prop, and therefore could be written as self-closing in JSX (e.g. `<img />`).

```ts
// from solid-js type definitions:
type VoidProps<P = {}> = P & { children?: never };
type VoidComponent<P = {}> = Component<VoidProps<P>>;
```

## Changes

- [X] Support `VoidComponent` in the same places that `ParentComponent` is supported
- [X] Add passing unit test to cover usage of `VoidComponent`