### PR TITLE
Update package.json

### DIFF
--- a/macro-package/package.json
+++ b/macro-package/package.json
@@ -2,9 +2,9 @@
 	"name": "undestructure-macros",
 	"description": "A placeholder package for babel-plugin-solid-undestructure macros",
 	"version": "0.0.1",
-	"main": "src/index.js",
-   "module": "src/index.js",
-	"types": "src/index.d.ts",
+	"main": "index.js",
+   	"module": "index.js",
+	"types": "index.d.ts",
 	"type": "module",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Properly pointing to main, module and types in package.json

In environments like `vite`, the `undestructure-macros` package is failing, because `package.json` points to files that don't exist.

```
Failed to resolve entry for package "undestructure-macros". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```